### PR TITLE
Add compatibility with Babel 7

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -59,7 +59,15 @@ export default function babelPluginReactComponentDataAttribute({types: t}) {
   }
 
   function shouldProcessPotentialComponent(path, name, state) {
-    if (!path.getFunctionParent().isProgram()) { return false; }
+    // Babel 7 returns null instead of Program from path.getFunctionParent if parent is not a function
+    if (typeof path.scope.getProgramParent === 'function') {
+      if (!path.scope.getProgramParent()) {
+        return false;
+      }
+    } else if (!path.getFunctionParent() || !path.getFunctionParent().isProgram()) {
+      return false;
+    }
+
     if (path.parentPath.isAssignmentExpression()) { return false; }
 
     const {onlyRootComponents = false} = state.opts || {};


### PR DESCRIPTION
Add support for Babel 7, which changes the behavior of `path.getFunctionParent()` (https://babeljs.io/blog/2017/03/01/upgrade-to-babel-7-for-tool-authors#babel-traverse).

New logic checks existence of new function `getProgramParent` on `path.scope`  to preserve backwards compatibility.  

Guarding against `path.getFunctionParent()` being falsey in this case may be unnecessary but seemed safest.